### PR TITLE
fix CMakeLists.txt

### DIFF
--- a/ar_pose/CMakeLists.txt
+++ b/ar_pose/CMakeLists.txt
@@ -29,7 +29,6 @@ generate_messages(DEPENDENCIES
 
 catkin_package(
   INCLUDE_DIRS include
-#  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS
     roscpp
     geometry_msgs

--- a/ar_pose/CMakeLists.txt
+++ b/ar_pose/CMakeLists.txt
@@ -29,7 +29,7 @@ generate_messages(DEPENDENCIES
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
+#  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS
     roscpp
     geometry_msgs


### PR DESCRIPTION
It appears that the ar_pose package does not provide any libraries, thus it is necessary to comment out the `LIBRARIES` line of the `catkin_package` command for other packages to be able to build against it.  I tested this building in Indigo on 14.04.
